### PR TITLE
upgraded to socialauth-4.2

### DIFF
--- a/xwiki-social-login-api/pom.xml
+++ b/xwiki-social-login-api/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.brickred</groupId>
       <artifactId>socialauth</artifactId>
-      <version>4.0</version>
+      <version>4.2</version>
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>


### PR DESCRIPTION
SocialAuth v4.2 is needed to use Twitter API v1.1.
